### PR TITLE
chore: add GitHub Actions deploy to gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,28 @@
+name: Build and deploy to gh-pages
+
+on:
+  push:
+    branches: [ "main", "master" ]
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build
+          publish_branch: gh-pages
+          user_name: github-actions[bot]
+          user_email: github-actions[bot]@users.noreply.github.com


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds the project with npm and deploys the production build to the gh-pages branch.

- Runs on push to `main` and on `workflow_dispatch`.
- Uses `npm ci` and `npm run build` to produce production artifacts.
- Deploys the `./build` directory to the `gh-pages` branch using the repository `GITHUB_TOKEN` via peaceiris/actions-gh-pages.

Please confirm the build output directory and update `publish_dir` in `.github/workflows/gh-pages.yml` if your project emits files to `dist` or another folder instead of `build`.