### PR TITLE
fix: publish dist to gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,7 +22,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build
+          publish_dir: ./dist
           publish_branch: gh-pages
           user_name: github-actions[bot]
           user_email: github-actions[bot]@users.noreply.github.com


### PR DESCRIPTION
Fixes the workflow to publish the Vite build output directory `./dist` instead of `./build`.

Vite outputs to `dist` by default; the previous workflow published an empty directory which resulted in a blank site. This PR updates `publish_dir` to `./dist` and re-deploys.

Please review and merge. After merging, the workflow will run and redeploy to gh-pages.