### PR TITLE
fix: set Vite base for GitHub Pages

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// Set base to the repository name so GitHub Pages serves assets from the correct subpath
+export default defineConfig({
+  base: '/pracofi/',
+  plugins: [react()]
+})


### PR DESCRIPTION
Add vite.config.js to set base to '/pracofi/' so built assets use the repository subpath on GitHub Pages. This prevents a blank white screen caused by absolute paths.

After merging, the workflow will run and redeploy to gh-pages.